### PR TITLE
i2c-mock: added i2c mocking capabilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 set(FLIGHT_CONTROL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/flight_control)
 set(H_DRIVERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/h_drivers)
 set(I2C_INTERFACE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/i2c_interface)
+set(I2C_MOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/i2c_mock)
 set(DRIVERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers)
 
 
@@ -28,6 +29,13 @@ set(FIREHORN_FC_SOURCES
     ${FLIGHT_CONTROL_DIR}/thresholds.h
 )   
 
+set(FIREHORN_MOCK_SOURCES
+    ${FIREHORN_FC_SOURCES}
+    ${I2C_INTERFACE_DIR}/i2c_interface.h
+    ${I2C_INTERFACE_DIR}/i2c_wrappers.h
+)
+
+add_library(fc_i2c_mock ${FIREHORN_MOCK_SOURCES})
 add_library(flight_computer ${FIREHORN_FC_SOURCES})
 
 target_include_directories(flight_computer PUBLIC
@@ -37,8 +45,24 @@ target_include_directories(flight_computer PUBLIC
     ${I2C_INTERFACE_DIR}
     ${DRIVERS_DIR}
 )
+target_include_directories(fc_i2c_mock PUBLIC
+    ${DATA_DIR}
+    ${H_DRIVERS_DIR}
+    ${FLIGHT_CONTROL_DIR}
+    ${I2C_MOCK_DIR}
+    ${DRIVERS_DIR}
+)
 
 target_link_libraries(flight_computer PUBLIC
+    ERT_RF_Protocol_Interface
+    Capsule
+    LoRa4Raspi
+    adxl375
+    bmi08
+    bmp3
+    gps
+)
+target_link_libraries(fc_i2c_mock PUBLIC
     ERT_RF_Protocol_Interface
     Capsule
     LoRa4Raspi

--- a/src/i2c_mock/devices/example.h
+++ b/src/i2c_mock/devices/example.h
@@ -1,0 +1,64 @@
+
+#ifndef I2C_MOCK_ADXL_H
+#define I2C_MOCK_ADXL_H
+
+#include "i2c_device.h"
+
+// This is an example of a really simple memory device that has one register
+// To hold some memory. It is used to check that the i2c_mock works properly.
+
+// Write procedure
+// reg_addr = 0 => set bits enabled
+// reg_addr = 1 => clear bits enabled
+// reg_addr = 2 => set reg with data
+
+// Read procedure
+// reg_addr = 0 => read value
+// reg_addr = 1 => read !value
+
+// Read device will just do the read / write
+
+#define REG_ENABLE 0
+#define REG_CLEAR 1
+#define REG_SET 2
+
+#define REG_READ 0
+#define REG_READ_NOT 1
+
+struct ExampleI2CDevice : I2CDevice {
+private:
+    uint8_t reg = 0;
+public:
+    uint8_t i2c_read  (uint8_t reg_addr, uint8_t* data, uint32_t len) override {
+        if (len == 0) return 0;
+
+        if (reg_addr == REG_READ) data[0] = reg;
+        if (reg_addr == REG_READ_NOT) data[0] = 0xFF ^ reg;
+
+        return 0;
+    }
+    uint8_t i2c_write (uint8_t reg_addr, const uint8_t* data, uint32_t len) override {
+        if (len == 0) return 0;
+
+        if (reg_addr == REG_ENABLE) reg |= data[0];
+        if (reg_addr == REG_CLEAR) reg &= 0xFF ^ data[0];
+        if (reg_addr == REG_SET) reg  = data[0];
+
+        return 0;
+    }
+
+    uint8_t i2c_read_device  (uint8_t* data, uint32_t len) override {
+        if (len == 0) return 0;
+
+        data[0] = reg;
+        return 0;
+    }
+    uint8_t i2c_write_device (const uint8_t* data, uint32_t len) override {
+        if (len == 0) return 0;
+
+        reg = data[0];
+        return 0;
+    }
+};
+
+#endif

--- a/src/i2c_mock/i2c_bus.cpp
+++ b/src/i2c_mock/i2c_bus.cpp
@@ -1,0 +1,59 @@
+
+#include "i2c_bus.h"
+
+void I2CBus::clear () {
+    devices.clear();
+    devices.resize(1 << sizeof(uint8_t), nullptr);
+    
+    device_open.clear();
+    device_open.resize(1 << sizeof(uint8_t), false);
+}
+void I2CBus::addDevice (uint8_t addr, I2CDevice* device) {
+    devices[addr] = device;
+}
+
+uint8_t I2CBus::i2c_open (uint8_t addr) {
+    if (devices[addr] == nullptr) return I2C_BUS_E_OPEN;
+    if (device_open[addr]) return I2C_BUS_E_ADDRESS_ALREADY_IN_USE;
+    device_open[addr] = true;
+    return 0;
+}
+uint8_t I2CBus::i2c_close (uint8_t addr) {
+    if (devices[addr] == nullptr) return I2C_BUS_E_CLOSE;
+    device_open[addr] = false;
+    return 0;
+}
+
+uint8_t I2CBus::i2c_read  (uint8_t addr, uint8_t reg_addr, uint8_t* data, uint32_t len) {
+    if (!device_open[addr]) return I2C_BUS_E_NOT_OPEN;
+
+    I2CDevice* device = devices[addr];
+    if (device->i2c_read(reg_addr, data, len) != 0) return I2C_BUS_E_READ;
+    
+    return 0;
+}
+uint8_t I2CBus::i2c_write (uint8_t addr, uint8_t reg_addr, const uint8_t* data, uint32_t len) {
+    if (!device_open[addr]) return I2C_BUS_E_NOT_OPEN;
+
+    I2CDevice* device = devices[addr];
+    if (device->i2c_write(reg_addr, data, len) != 0) return I2C_BUS_E_WRITE;
+    
+    return 0;
+}
+
+uint8_t I2CBus::i2c_read_device  (uint8_t addr, uint8_t* data, uint32_t len) {
+    if (!device_open[addr]) return I2C_BUS_E_NOT_OPEN;
+
+    I2CDevice* device = devices[addr];
+    if (device->i2c_read_device(data, len) != 0) return I2C_BUS_E_READ;
+    
+    return 0;
+}
+uint8_t I2CBus::i2c_write_device (uint8_t addr, const uint8_t* data, uint32_t len) {
+    if (!device_open[addr]) return I2C_BUS_E_NOT_OPEN;
+
+    I2CDevice* device = devices[addr];
+    if (device->i2c_write_device(data, len) != 0) return I2C_BUS_E_WRITE;
+    
+    return 0;
+}

--- a/src/i2c_mock/i2c_bus.h
+++ b/src/i2c_mock/i2c_bus.h
@@ -1,0 +1,46 @@
+
+#ifndef I2C_BUS_H
+#define I2C_BUS_H
+
+#include <vector>
+#include "i2c_device.h"
+
+#include <cstdint>
+
+#define I2C_BUS_OK 0
+#define I2C_BUS_E_OPEN -1
+#define I2C_BUS_E_CLOSE -2
+#define I2C_BUS_E_READ -3
+#define I2C_BUS_E_WRITE -4
+#define I2C_BUS_E_ADDRESS_ALREADY_IN_USE -5
+#define I2C_BUS_E_NOT_OPEN -6
+
+struct I2CBus {
+private:
+    std::vector<I2CDevice*> devices;
+    std::vector<bool> device_open;
+    
+    I2CDevice* getDevice (uint8_t addr);
+public:
+    void addDevice (uint8_t addr, I2CDevice* device);
+    void clear();
+
+    uint8_t i2c_open  (uint8_t addr);
+    uint8_t i2c_close (uint8_t addr);
+
+    uint8_t i2c_read  (uint8_t addr, uint8_t reg_addr, uint8_t* data, uint32_t len);
+    uint8_t i2c_write (uint8_t addr, uint8_t reg_addr, const uint8_t* data, uint32_t len);
+
+    uint8_t i2c_read_device  (uint8_t addr, uint8_t* data, uint32_t len);
+    uint8_t i2c_write_device (uint8_t addr, const uint8_t* data, uint32_t len);
+
+    static I2CBus& getInstance() {
+        static I2CBus instance;
+        instance.devices.resize(1 << sizeof(uint8_t), nullptr);
+        instance.device_open.resize(1 << sizeof(uint8_t), false);
+
+        return instance;
+    }
+};
+
+#endif

--- a/src/i2c_mock/i2c_device.h
+++ b/src/i2c_mock/i2c_device.h
@@ -1,0 +1,16 @@
+
+#ifndef I2C_DEVICE_H
+#define I2C_DEVICE_H
+
+#include <vector>
+#include <cstdint>
+
+struct I2CDevice {
+    virtual uint8_t i2c_read  (uint8_t reg_addr, uint8_t* data, uint32_t len) = 0;
+    virtual uint8_t i2c_write (uint8_t reg_addr, const uint8_t* data, uint32_t len) = 0;
+
+    virtual uint8_t i2c_read_device  (uint8_t* data, uint32_t len) = 0;
+    virtual uint8_t i2c_write_device (const uint8_t* data, uint32_t len) = 0;
+};
+
+#endif

--- a/src/i2c_mock/i2c_interface.cpp
+++ b/src/i2c_mock/i2c_interface.cpp
@@ -1,0 +1,119 @@
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <cstring>
+
+#include "i2c_interface.h"
+#include "i2c_wrappers.h"
+#include "i2c_bus.h"
+
+void I2CInterface::initialize() {
+    std::memset(handle_list, 0, sizeof(handle_list));
+    std::memset(i2c_addr_list, 0, sizeof(i2c_addr_list));
+}
+
+void I2CInterface::terminate() {
+    std::memset(handle_list, 0, sizeof(handle_list));
+    std::memset(i2c_addr_list, 0, sizeof(i2c_addr_list));
+}
+
+void I2CInterface::open(uint8_t addr) {
+    if (I2CBus::getInstance().i2c_open(addr) != 0)
+        throw I2CInterfaceException("Failed to open I2C device");
+    handle_list[addr] = addr;
+    i2c_addr_list[addr] = addr;
+    usleep(10000); // Delay for stabilization
+}
+
+void I2CInterface::close(uint8_t addr) {
+    if (I2CBus::getInstance().i2c_close(handle_list[addr]) != 0) {
+        throw I2CInterfaceException("Failed to close I2C device");
+    }
+    handle_list[addr] = 0;
+    i2c_addr_list[addr] = 0;
+}
+
+void I2CInterface::write(uint8_t addr, uint8_t reg_addr, const uint8_t* data, uint32_t len) {
+    if (I2CBus::getInstance().i2c_write(addr, reg_addr, data, len) != 0)
+        throw I2CInterfaceException("I2C write operation failed");
+}
+
+void I2CInterface::read(uint8_t addr, uint8_t reg_addr, uint8_t* data, uint32_t len) {
+    if (I2CBus::getInstance().i2c_read(addr, reg_addr, data, len) != 0)
+        throw I2CInterfaceException("I2C read operation failed");
+}
+
+void I2CInterface::readDevice(uint8_t addr, uint8_t* data, uint32_t len) {
+    if (I2CBus::getInstance().i2c_read_device(addr, data, len) != 0)
+        throw I2CInterfaceException("I2C read operation failed");
+}
+
+void I2CInterface::writeDevice(uint8_t addr, uint8_t* data, uint32_t len) {
+    if (I2CBus::getInstance().i2c_write_device(addr, data, len) != 0)
+        throw I2CInterfaceException("I2C write operation failed");
+}
+
+void* I2CInterface::get_intf_ptr(uint8_t addr) {
+    if (i2c_addr_list[addr] == addr) {
+        return &i2c_addr_list[addr];
+    } else {
+        throw I2CInterfaceException("I2C device at address not initialized");
+    }
+}
+
+extern "C" {
+
+int8_t i2c_open(uint8_t addr) {
+    try {
+        I2CInterface::getInstance().open(addr);
+        return 0; // Success
+    } catch (const I2CInterfaceException& e) {
+        return COMM_FAIL;
+    }
+}
+
+int8_t i2c_close(uint8_t addr) {
+    try {
+        I2CInterface::getInstance().close(addr);
+        return 0; // Success
+    } catch (const I2CInterfaceException& e) {
+        return COMM_FAIL;
+    }
+}
+
+void i2c_delay_us(uint32_t period, void* intf_ptr) {
+    // Simple wrapper, exception handling is likely unnecessary here
+    usleep(period);
+}
+
+int8_t i2c_read(uint8_t reg_addr, uint8_t* reg_data, uint32_t len, void* intf_ptr) {
+    try {
+        uint8_t addr = *(reinterpret_cast<uint8_t*>(intf_ptr)); // Assuming intf_ptr points to the address
+        I2CInterface::getInstance().read(addr, reg_addr, reg_data, len);
+        return 0; // Success
+    } catch (const I2CInterfaceException& e) {
+        return COMM_FAIL;
+    }
+}
+
+int8_t i2c_write(uint8_t reg_addr, const uint8_t* reg_data, uint32_t len, void* intf_ptr) {
+    try {
+        uint8_t addr = *(reinterpret_cast<uint8_t*>(intf_ptr));
+        I2CInterface::getInstance().write(addr, reg_addr, reg_data, len);
+        return 0; // Success
+    } catch (const I2CInterfaceException& e) {
+        return COMM_FAIL;
+    }
+}
+
+int8_t get_intf_ptr(uint8_t addr, void **intf_ptr) {
+    try {
+        *intf_ptr = I2CInterface::getInstance().get_intf_ptr(addr);
+        return 0;
+    } catch (const I2CInterfaceException& e) {
+        return COMM_FAIL;
+    }
+}
+
+} //END OF C FUNCTIONS

--- a/src/i2c_mock/i2c_physics.h
+++ b/src/i2c_mock/i2c_physics.h
@@ -1,0 +1,43 @@
+
+#ifndef I2C_PHYSICS_H
+#define I2C_PHYSICS_H
+
+struct Vec3 {
+    float x, y, z;
+};
+
+struct I2CPhysics {
+private:
+    static I2CPhysics* physics;
+public:
+    static I2CPhysics* getInstance () {
+        return physics;
+    }
+    static void setInstance (I2CPhysics* _physics) {
+        I2CPhysics::physics = _physics;
+    }
+
+    virtual void start () = 0;
+
+    virtual Vec3 position () = 0;
+    virtual Vec3 speed () = 0;
+    virtual Vec3 acceleration () = 0;
+
+    virtual Vec3 angle () = 0;
+    virtual Vec3 angular_speed () = 0;
+    virtual Vec3 angular_acceleration () = 0;
+};
+
+struct I2CPhysics_NoMovement : public I2CPhysics {
+    void start () override {}
+
+    Vec3 position () override { return { 0, 0, 0 }; }
+    Vec3 speed () override { return { 0, 0, 0 }; }
+    Vec3 acceleration () override { return { 0, 0, 0 }; }
+
+    Vec3 angle () override { return { 0, 0, 0 }; }
+    Vec3 angular_speed () override { return { 0, 0, 0 }; }
+    Vec3 angular_acceleration () override { return { 0, 0, 0 }; }
+};
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,10 @@ add_executable(data_logger_test DataLogger_test.cpp)
 target_link_libraries(data_logger_test flight_computer)
 add_test(NAME DataLoggerTest COMMAND data_logger_test)
 
+add_executable(i2c_mock_test i2c_mock_test.cpp)
+target_link_libraries(i2c_mock_test fc_i2c_mock)
+add_test(NAME I2CMockTest COMMAND i2c_mock_test)
+
 add_executable(bmp390_test BMP390_test.cpp)
 target_link_libraries(bmp390_test bmp3)
 

--- a/tests/i2c_mock_test.cpp
+++ b/tests/i2c_mock_test.cpp
@@ -1,0 +1,57 @@
+
+#include "i2c_bus.h"
+#include "i2c_wrappers.h"
+#include "i2c_interface.h"
+#include "devices/example.h"
+#include <stdio.h>
+
+#define EXAMPLE_ADDRESS 0x42
+
+int main (void) {
+    ExampleI2CDevice device;
+    I2CBus & bus = I2CBus::getInstance();
+    bus.addDevice(EXAMPLE_ADDRESS, &device);
+
+    I2CInterface & intf = I2CInterface::getInstance();
+
+    if (i2c_open( EXAMPLE_ADDRESS ) != 0) return 1;
+    
+    void* intf_ptr;
+    if (get_intf_ptr( EXAMPLE_ADDRESS, &intf_ptr) != 0) return 1;
+
+    uint8_t buffer[1] = { 42 };
+    if (i2c_read( REG_READ, buffer, 1, intf_ptr ) != 0) return 1;
+    if (buffer[0] != 0) return 1;
+    if (i2c_read( REG_READ_NOT, buffer, 1, intf_ptr ) != 0) return 1;
+    if (buffer[0] != 255) return 1;
+
+    buffer[0] = 0x43;
+    if (i2c_write(REG_ENABLE, buffer, 1, intf_ptr) != 0) return 1;
+
+    buffer[0] = 0;
+    if (i2c_read( REG_READ, buffer, 1, intf_ptr ) != 0) return 1;
+    if (buffer[0] != 0x43) return 1;
+
+    buffer[0] = 0x42;
+    if (i2c_write(REG_CLEAR, buffer, 1, intf_ptr) != 0) return 1;
+
+    buffer[0] = 0;
+    intf.readDevice( EXAMPLE_ADDRESS, buffer, 1 );
+    if (buffer[0] != 0x01) return 1;
+
+    buffer[0] = 0x42;
+    if (i2c_write(REG_SET, buffer, 1, intf_ptr) != 0) return 1;
+
+    buffer[0] = 0;
+    if (i2c_read( REG_READ, buffer, 1, intf_ptr ) != 0) return 1;
+    if (buffer[0] != 0x42) return 1;
+
+    buffer[0] = 0x43;
+    intf.writeDevice( EXAMPLE_ADDRESS, buffer, 1 );
+
+    buffer[0] = 0;
+    if (i2c_read( REG_READ_NOT, buffer, 1, intf_ptr ) != 0) return 1;
+    if (buffer[0] != 0xBC) return 1;
+
+    if (i2c_close(EXAMPLE_ADDRESS) != 0) return 1;
+}


### PR DESCRIPTION
Added a virtual I2C bus that overrides the I2C Interface when compiled using the library fc_i2c_mock.

Can be used to test high/low level drivers by implementing the virtual component using the I2CPhysics engine as a provider for the data.